### PR TITLE
Manual Detail Adjustment for 2020

### DIFF
--- a/Description.json
+++ b/Description.json
@@ -1,6 +1,6 @@
 {
     "productMarketingInfo": {
-        "version": "20.0.0.0",
+        "version": "20.0.0.1",
         "localizedContent": [
             {
                 "langCode": "en-US",

--- a/Source/DataGenerator.cs
+++ b/Source/DataGenerator.cs
@@ -437,7 +437,17 @@ namespace BIM.STLExport
                 {
                     continue;
                 }
-                Mesh mesh = face.Triangulate();
+                Mesh mesh;
+
+                if (null != m_Settings.Detail)
+                {
+                    mesh = face.Triangulate((double)m_Settings.Detail);
+                }
+                else
+                {
+                    mesh = face.Triangulate();
+                }
+
                 if (null == mesh)
                 {
                     continue;

--- a/Source/STLExportForm.Designer.cs
+++ b/Source/STLExportForm.Designer.cs
@@ -53,6 +53,7 @@ namespace BIM.STLExport
             this.btnSave = new System.Windows.Forms.Button();
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tpGeneral = new System.Windows.Forms.TabPage();
+            this.cbExportSharedCoordinates = new System.Windows.Forms.CheckBox();
             this.cbExportColor = new System.Windows.Forms.CheckBox();
             this.comboBox_DUT = new System.Windows.Forms.ComboBox();
             this.label1 = new System.Windows.Forms.Label();
@@ -61,14 +62,20 @@ namespace BIM.STLExport
             this.rbAscii = new System.Windows.Forms.RadioButton();
             this.rbBinary = new System.Windows.Forms.RadioButton();
             this.tpCategories = new System.Windows.Forms.TabPage();
+            this.tvCategories = new System.Windows.Forms.TreeView();
             this.btnCheckNone = new System.Windows.Forms.Button();
             this.btnCheckAll = new System.Windows.Forms.Button();
-            this.cbExportSharedCoordinates = new System.Windows.Forms.CheckBox();
-            this.tvCategories = new System.Windows.Forms.TreeView();
+            this.label2 = new System.Windows.Forms.Label();
+            this.trbDetail = new System.Windows.Forms.TrackBar();
+            this.tbDetail = new System.Windows.Forms.TextBox();
+            this.label3 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
             this.tabControl1.SuspendLayout();
             this.tpGeneral.SuspendLayout();
             this.gbSTLFormat.SuspendLayout();
             this.tpCategories.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.trbDetail)).BeginInit();
             this.SuspendLayout();
             // 
             // btnCancel
@@ -103,6 +110,12 @@ namespace BIM.STLExport
             // tpGeneral
             // 
             this.tpGeneral.BackColor = System.Drawing.SystemColors.Control;
+            this.tpGeneral.Controls.Add(this.label5);
+            this.tpGeneral.Controls.Add(this.label4);
+            this.tpGeneral.Controls.Add(this.label3);
+            this.tpGeneral.Controls.Add(this.tbDetail);
+            this.tpGeneral.Controls.Add(this.trbDetail);
+            this.tpGeneral.Controls.Add(this.label2);
             this.tpGeneral.Controls.Add(this.cbExportSharedCoordinates);
             this.tpGeneral.Controls.Add(this.cbExportColor);
             this.tpGeneral.Controls.Add(this.comboBox_DUT);
@@ -111,6 +124,12 @@ namespace BIM.STLExport
             this.tpGeneral.Controls.Add(this.gbSTLFormat);
             resources.ApplyResources(this.tpGeneral, "tpGeneral");
             this.tpGeneral.Name = "tpGeneral";
+            // 
+            // cbExportSharedCoordinates
+            // 
+            resources.ApplyResources(this.cbExportSharedCoordinates, "cbExportSharedCoordinates");
+            this.cbExportSharedCoordinates.Name = "cbExportSharedCoordinates";
+            this.cbExportSharedCoordinates.UseVisualStyleBackColor = true;
             // 
             // cbExportColor
             // 
@@ -168,6 +187,12 @@ namespace BIM.STLExport
             resources.ApplyResources(this.tpCategories, "tpCategories");
             this.tpCategories.Name = "tpCategories";
             // 
+            // tvCategories
+            // 
+            this.tvCategories.CheckBoxes = true;
+            resources.ApplyResources(this.tvCategories, "tvCategories");
+            this.tvCategories.Name = "tvCategories";
+            // 
             // btnCheckNone
             // 
             resources.ApplyResources(this.btnCheckNone, "btnCheckNone");
@@ -182,17 +207,39 @@ namespace BIM.STLExport
             this.btnCheckAll.UseVisualStyleBackColor = true;
             this.btnCheckAll.Click += new System.EventHandler(this.btnCheckAll_Click);
             // 
-            // cbExportSharedCoordinates
+            // label2
             // 
-            resources.ApplyResources(this.cbExportSharedCoordinates, "cbExportSharedCoordinates");
-            this.cbExportSharedCoordinates.Name = "cbExportSharedCoordinates";
-            this.cbExportSharedCoordinates.UseVisualStyleBackColor = true;
+            resources.ApplyResources(this.label2, "label2");
+            this.label2.Name = "label2";
             // 
-            // tvCategories
+            // trbDetail
             // 
-            this.tvCategories.CheckBoxes = true;
-            resources.ApplyResources(this.tvCategories, "tvCategories");
-            this.tvCategories.Name = "tvCategories";
+            resources.ApplyResources(this.trbDetail, "trbDetail");
+            this.trbDetail.Maximum = 100;
+            this.trbDetail.Name = "trbDetail";
+            this.trbDetail.TickFrequency = 10;
+            this.trbDetail.ValueChanged += new System.EventHandler(this.trbDetail_ValueChanged);
+            // 
+            // tbDetail
+            // 
+            resources.ApplyResources(this.tbDetail, "tbDetail");
+            this.tbDetail.Name = "tbDetail";
+            this.tbDetail.Validating += new System.ComponentModel.CancelEventHandler(this.tbDetail_Validating);
+            // 
+            // label3
+            // 
+            resources.ApplyResources(this.label3, "label3");
+            this.label3.Name = "label3";
+            // 
+            // label4
+            // 
+            resources.ApplyResources(this.label4, "label4");
+            this.label4.Name = "label4";
+            // 
+            // label5
+            // 
+            resources.ApplyResources(this.label5, "label5");
+            this.label5.Name = "label5";
             // 
             // STLExportForm
             // 
@@ -211,6 +258,7 @@ namespace BIM.STLExport
             this.tpGeneral.PerformLayout();
             this.gbSTLFormat.ResumeLayout(false);
             this.tpCategories.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.trbDetail)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -234,5 +282,11 @@ namespace BIM.STLExport
         private System.Windows.Forms.CheckBox cbExportColor;
         private System.Windows.Forms.CheckBox cbExportSharedCoordinates;
         private System.Windows.Forms.TreeView tvCategories;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.TextBox tbDetail;
+        private System.Windows.Forms.TrackBar trbDetail;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label label3;
     }
 }

--- a/Source/STLExportForm.resx
+++ b/Source/STLExportForm.resx
@@ -198,6 +198,162 @@
   <data name="&gt;&gt;btnSave.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="label5.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>81, 296</value>
+  </data>
+  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>27, 13</value>
+  </data>
+  <data name="label5.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="label5.Text" xml:space="preserve">
+    <value>10%</value>
+  </data>
+  <data name="&gt;&gt;label5.Name" xml:space="preserve">
+    <value>label5</value>
+  </data>
+  <data name="&gt;&gt;label5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
+    <value>tpGeneral</value>
+  </data>
+  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label4.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
+    <value>247, 295</value>
+  </data>
+  <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
+    <value>33, 13</value>
+  </data>
+  <data name="label4.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="label4.Text" xml:space="preserve">
+    <value>100%</value>
+  </data>
+  <data name="&gt;&gt;label4.Name" xml:space="preserve">
+    <value>label4</value>
+  </data>
+  <data name="&gt;&gt;label4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
+    <value>tpGeneral</value>
+  </data>
+  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="label3.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>46, 295</value>
+  </data>
+  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>29, 13</value>
+  </data>
+  <data name="label3.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>Auto</value>
+  </data>
+  <data name="&gt;&gt;label3.Name" xml:space="preserve">
+    <value>label3</value>
+  </data>
+  <data name="&gt;&gt;label3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
+    <value>tpGeneral</value>
+  </data>
+  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tbDetail.Location" type="System.Drawing.Point, System.Drawing">
+    <value>286, 268</value>
+  </data>
+  <data name="tbDetail.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 20</value>
+  </data>
+  <data name="tbDetail.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="tbDetail.Text" xml:space="preserve">
+    <value>Auto</value>
+  </data>
+  <data name="&gt;&gt;tbDetail.Name" xml:space="preserve">
+    <value>tbDetail</value>
+  </data>
+  <data name="&gt;&gt;tbDetail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tbDetail.Parent" xml:space="preserve">
+    <value>tpGeneral</value>
+  </data>
+  <data name="&gt;&gt;tbDetail.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="trbDetail.Location" type="System.Drawing.Point, System.Drawing">
+    <value>63, 264</value>
+  </data>
+  <data name="trbDetail.Size" type="System.Drawing.Size, System.Drawing">
+    <value>211, 45</value>
+  </data>
+  <data name="trbDetail.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;trbDetail.Name" xml:space="preserve">
+    <value>trbDetail</value>
+  </data>
+  <data name="&gt;&gt;trbDetail.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;trbDetail.Parent" xml:space="preserve">
+    <value>tpGeneral</value>
+  </data>
+  <data name="&gt;&gt;trbDetail.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>17, 268</value>
+  </data>
+  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>37, 13</value>
+  </data>
+  <data name="label2.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>Detail:</value>
+  </data>
+  <data name="&gt;&gt;label2.Name" xml:space="preserve">
+    <value>label2</value>
+  </data>
+  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+    <value>tpGeneral</value>
+  </data>
+  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
   <data name="cbExportSharedCoordinates.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -223,7 +379,7 @@
     <value>tpGeneral</value>
   </data>
   <data name="&gt;&gt;cbExportSharedCoordinates.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>6</value>
   </data>
   <data name="cbExportColor.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -250,7 +406,7 @@
     <value>tpGeneral</value>
   </data>
   <data name="&gt;&gt;cbExportColor.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>7</value>
   </data>
   <data name="comboBox_DUT.Location" type="System.Drawing.Point, System.Drawing">
     <value>63, 237</value>
@@ -271,7 +427,7 @@
     <value>tpGeneral</value>
   </data>
   <data name="&gt;&gt;comboBox_DUT.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>8</value>
   </data>
   <data name="label1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -298,7 +454,7 @@
     <value>tpGeneral</value>
   </data>
   <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>9</value>
   </data>
   <data name="cbIncludeLinked.Location" type="System.Drawing.Point, System.Drawing">
     <value>23, 114</value>
@@ -322,7 +478,166 @@
     <value>tpGeneral</value>
   </data>
   <data name="&gt;&gt;cbIncludeLinked.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;rbAscii.Name" xml:space="preserve">
+    <value>rbAscii</value>
+  </data>
+  <data name="&gt;&gt;rbAscii.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rbAscii.Parent" xml:space="preserve">
+    <value>gbSTLFormat</value>
+  </data>
+  <data name="&gt;&gt;rbAscii.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;rbBinary.Name" xml:space="preserve">
+    <value>rbBinary</value>
+  </data>
+  <data name="&gt;&gt;rbBinary.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;rbBinary.Parent" xml:space="preserve">
+    <value>gbSTLFormat</value>
+  </data>
+  <data name="&gt;&gt;rbBinary.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="gbSTLFormat.Location" type="System.Drawing.Point, System.Drawing">
+    <value>23, 21</value>
+  </data>
+  <data name="gbSTLFormat.Size" type="System.Drawing.Size, System.Drawing">
+    <value>326, 73</value>
+  </data>
+  <data name="gbSTLFormat.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="gbSTLFormat.Text" xml:space="preserve">
+    <value>STL Format</value>
+  </data>
+  <data name="&gt;&gt;gbSTLFormat.Name" xml:space="preserve">
+    <value>gbSTLFormat</value>
+  </data>
+  <data name="&gt;&gt;gbSTLFormat.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;gbSTLFormat.Parent" xml:space="preserve">
+    <value>tpGeneral</value>
+  </data>
+  <data name="&gt;&gt;gbSTLFormat.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="tpGeneral.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpGeneral.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpGeneral.Size" type="System.Drawing.Size, System.Drawing">
+    <value>367, 324</value>
+  </data>
+  <data name="tpGeneral.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="tpGeneral.Text" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="&gt;&gt;tpGeneral.Name" xml:space="preserve">
+    <value>tpGeneral</value>
+  </data>
+  <data name="&gt;&gt;tpGeneral.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpGeneral.Parent" xml:space="preserve">
+    <value>tabControl1</value>
+  </data>
+  <data name="&gt;&gt;tpGeneral.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;tvCategories.Name" xml:space="preserve">
+    <value>tvCategories</value>
+  </data>
+  <data name="&gt;&gt;tvCategories.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TreeView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tvCategories.Parent" xml:space="preserve">
+    <value>tpCategories</value>
+  </data>
+  <data name="&gt;&gt;tvCategories.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;btnCheckNone.Name" xml:space="preserve">
+    <value>btnCheckNone</value>
+  </data>
+  <data name="&gt;&gt;btnCheckNone.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCheckNone.Parent" xml:space="preserve">
+    <value>tpCategories</value>
+  </data>
+  <data name="&gt;&gt;btnCheckNone.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;btnCheckAll.Name" xml:space="preserve">
+    <value>btnCheckAll</value>
+  </data>
+  <data name="&gt;&gt;btnCheckAll.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;btnCheckAll.Parent" xml:space="preserve">
+    <value>tpCategories</value>
+  </data>
+  <data name="&gt;&gt;btnCheckAll.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="tpCategories.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="tpCategories.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="tpCategories.Size" type="System.Drawing.Size, System.Drawing">
+    <value>367, 324</value>
+  </data>
+  <data name="tpCategories.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="tpCategories.Text" xml:space="preserve">
+    <value>Categories</value>
+  </data>
+  <data name="&gt;&gt;tpCategories.Name" xml:space="preserve">
+    <value>tpCategories</value>
+  </data>
+  <data name="&gt;&gt;tpCategories.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tpCategories.Parent" xml:space="preserve">
+    <value>tabControl1</value>
+  </data>
+  <data name="&gt;&gt;tpCategories.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="tabControl1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 12</value>
+  </data>
+  <data name="tabControl1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>375, 350</value>
+  </data>
+  <data name="tabControl1.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;tabControl1.Name" xml:space="preserve">
+    <value>tabControl1</value>
+  </data>
+  <data name="&gt;&gt;tabControl1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabControl1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;tabControl1.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="rbAscii.Location" type="System.Drawing.Point, System.Drawing">
     <value>167, 19</value>
@@ -371,57 +686,6 @@
   </data>
   <data name="&gt;&gt;rbBinary.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="gbSTLFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>23, 21</value>
-  </data>
-  <data name="gbSTLFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>326, 73</value>
-  </data>
-  <data name="gbSTLFormat.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="gbSTLFormat.Text" xml:space="preserve">
-    <value>STL Format</value>
-  </data>
-  <data name="&gt;&gt;gbSTLFormat.Name" xml:space="preserve">
-    <value>gbSTLFormat</value>
-  </data>
-  <data name="&gt;&gt;gbSTLFormat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;gbSTLFormat.Parent" xml:space="preserve">
-    <value>tpGeneral</value>
-  </data>
-  <data name="&gt;&gt;gbSTLFormat.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="tpGeneral.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpGeneral.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>367, 324</value>
-  </data>
-  <data name="tpGeneral.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="tpGeneral.Text" xml:space="preserve">
-    <value>General</value>
-  </data>
-  <data name="&gt;&gt;tpGeneral.Name" xml:space="preserve">
-    <value>tpGeneral</value>
-  </data>
-  <data name="&gt;&gt;tpGeneral.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpGeneral.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tpGeneral.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="tvCategories.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 6</value>
@@ -491,54 +755,6 @@
   </data>
   <data name="&gt;&gt;btnCheckAll.ZOrder" xml:space="preserve">
     <value>2</value>
-  </data>
-  <data name="tpCategories.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="tpCategories.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="tpCategories.Size" type="System.Drawing.Size, System.Drawing">
-    <value>367, 324</value>
-  </data>
-  <data name="tpCategories.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="tpCategories.Text" xml:space="preserve">
-    <value>Categories</value>
-  </data>
-  <data name="&gt;&gt;tpCategories.Name" xml:space="preserve">
-    <value>tpCategories</value>
-  </data>
-  <data name="&gt;&gt;tpCategories.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tpCategories.Parent" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tpCategories.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="tabControl1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 12</value>
-  </data>
-  <data name="tabControl1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>375, 350</value>
-  </data>
-  <data name="tabControl1.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;tabControl1.Name" xml:space="preserve">
-    <value>tabControl1</value>
-  </data>
-  <data name="&gt;&gt;tabControl1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabControl1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;tabControl1.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -53,6 +53,7 @@ namespace BIM.STLExport
         private bool m_exportSharedCoordinates;
         private List<Category> m_SelectedCategories;
         private DisplayUnitType m_Units;
+        private double? m_Detail;
 
         /// <summary>
         /// Binary or ASCII STL file.
@@ -128,6 +129,14 @@ namespace BIM.STLExport
               }
         }
 
+        public double? Detail
+        {
+            get
+            {
+                return m_Detail;
+            }
+        }
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -142,6 +151,7 @@ namespace BIM.STLExport
             m_exportSharedCoordinates = false;
             m_SelectedCategories = new List<Category>();
             m_Units = DisplayUnitType.DUT_UNDEFINED;
+            m_Detail = null;
         }
 
         /// <summary>
@@ -151,8 +161,9 @@ namespace BIM.STLExport
         /// <param name="exportRange">The export range.</param>
         /// <param name="includeLinkedModels">True to include linked models, false otherwise.</param>
         /// <param name="selectedCategories">The selected categories to be included.</param>
+        /// <param name="detail">The detail level between 0 and 1 with which to save the STL</param>
         public Settings(SaveFormat saveFormat, ElementsExportRange exportRange, bool includeLinkedModels,bool exportColor,bool exportSharedCoordinates,
-            List<Category> selectedCategories, DisplayUnitType units)
+            List<Category> selectedCategories, DisplayUnitType units, double? detail)
         {
             m_SaveFormat = saveFormat;
             m_ExportRange = exportRange;
@@ -161,6 +172,7 @@ namespace BIM.STLExport
             m_exportSharedCoordinates = exportSharedCoordinates;
             m_SelectedCategories = selectedCategories;
             m_Units = units;
+            m_Detail = detail;
         }
     }
 }


### PR DESCRIPTION
This is a rebase of my changes for 2018 onto 2020 which add a manual detail adjustment slider to the extension. I have tested these changes on a newly downloaded copy of Revit 2020 today.

The value of this added slider is that it allows for producing meshes with sufficient quality to 3D print without significant faceting. This is important to our use case for Revit in education as the students have a base level of knowledge in 3D modeling from building houses in Revit, a skillset which they also use for modeling parts to be 3D printed for their robots. Unfortunately, in addition to being ugly, parts printed from STLs exported using the Autodesk extension fit together poorly due to their being more like polygons than circles. This pull request's changes fix this because they allow the use of a higher quality mesh if desired.

The new UI defaults to the automatic quality setting as is currently used in the Autodesk version of the extension, and simply exposes a new knob for those who want to use it.

This is what is currently exported, which produces visible facets on curves on prints on consumer-grade 3D printers:

![image](https://user-images.githubusercontent.com/6652840/60240438-384e7080-986e-11e9-9f7f-dc907c371ae0.png)

Compare this to the quality setting of approximately 96% using my changes:

![high quality stl](https://user-images.githubusercontent.com/6652840/60240187-6e3f2500-986d-11e9-952b-7133f02b7e2d.png)

Here's the new UI:
![stlplugin](https://user-images.githubusercontent.com/6652840/60240310-c6762700-986d-11e9-88e6-3b865ce8fd79.png)

I am fine with signing a CLA for these changes.